### PR TITLE
Patch error caused by spreading key value

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -54,7 +54,7 @@ export function DraftJsRender(props: Props): JSX.Element {
     <View>
       {blocks.map<JSX.Element>((block: Block) => {
         const { key, type, text, data, inlineStyleRanges, entityRanges, depth } = block;
-        const itemData = { key, type, text, data, inlineStyleRanges, entityRanges, depth };
+        const itemData = { type, text, data, inlineStyleRanges, entityRanges, depth };
 
         switch (type) {
           case 'unstyled':


### PR DESCRIPTION
<img width="697" alt="Screenshot 2025-06-23 at 14 29 39" src="https://github.com/user-attachments/assets/3f6df5a6-f937-44e7-a64d-f40345326fd7" />

ItemData key value should not be included in the spread props to `<DraftJsText/>`. The key is still properly passed to the parent `<View key={key}>` elements for React's reconciliation